### PR TITLE
[Git] Local에서의 rebase 중 여러 conflict 해결

### DIFF
--- a/src/main/resources/conflict-test-2.txt
+++ b/src/main/resources/conflict-test-2.txt
@@ -1,1 +1,1 @@
-여러 개의 conflict가 생기는 상황에서 rebase 확인하기
+rebase 과정에서 2번째 conflict 해결

--- a/src/main/resources/conflict-test.txt
+++ b/src/main/resources/conflict-test.txt
@@ -1,3 +1,7 @@
+rebase 과정에서 첫 번째 conflict 해결
+
 Line1
 Line2
 Line3
+
+PR을 올리기 전에 (push하기 전에) rebase를 하는 상황 만들기


### PR DESCRIPTION
## 확인 사항

1. main에서 총 2개의 파일에 변경 사항을 만들고, `lab/#4-second-git` 브랜치에서 동일한 파일을 수정한다.
따라서, 총 2개의 conflict가 발생한다.

2. commit을 push하기 전에, 먼저 main 브랜치에서 최신 변경사항을 pull 해온 후, 다시 `lab/#4-second-git` 브랜치로 이동하여 `git rebase main` 을 수행한다.

3. 현재 브랜치의  head를 최신의 main으로 변경하는 과정에서 conflict가 2개 발생한다. 따라서, 아래와 같이 `REBASE 1|2` 가 표시된다.

![image](https://github.com/somsom13/lab/assets/70891072/87b0b653-3870-4eea-b8c9-a989c8369579)

5. conflict에 우선 하나의 conflict 파일이 표시된다. 이를 해결하면 좌측 커밋창에 변경된 커밋이 표시된다. 이를 새롭게 commit 하지 말고, 터미널에서 `git rebase --continue`를 수행한다.

6. 2번째 conflict 파일이 표시되고, 첫 번째 conflict 를 해결할 때 보였던 추가로 커밋할 내역이 창에서 사라진다. 4번과 마찬가지로 충돌 내역을 해결하고 별도의 커밋 없이 `git rebase --continue` 를 입력하면 충돌이 해결된다.

7. 이후 다시 `git push origin 내브랜치` 를 수행하면 커밋이 깔끔하게 정리되어 올라간다.

## 실수한 부분
하나의 브랜치에서 PR을 열고, 해당 브랜치에서 다시 작업을 수행한다면 꼭 `git pull origin 내브랜치` 로 remote 와 싱크를 맞추자! (안그러면 또 force push 해야함)


